### PR TITLE
refactor(anthropic-agent): implement multi-turn iterative tool calling loop

### DIFF
--- a/examples/anthropic/anthropic_with_pre_planned_tool.py
+++ b/examples/anthropic/anthropic_with_pre_planned_tool.py
@@ -1,6 +1,7 @@
 import os
 
 import anthropic
+import json
 from aci import ACI
 from aci.types.functions import FunctionDefinitionFormat
 from anthropic.types.content_block import TextBlock, ToolUseBlock
@@ -109,7 +110,7 @@ def main() -> None:
                     "content": [{
                         "type": "tool_result",
                         "id": content_block.id,
-                        "content": str(result),
+                        "content": json.dumps(result, ensure_ascii=False),
                     }]
                 })
 

--- a/examples/anthropic/anthropic_with_pre_planned_tool.py
+++ b/examples/anthropic/anthropic_with_pre_planned_tool.py
@@ -106,10 +106,10 @@ def main() -> None:
 
                 # Add tool call result to message list
                 messages.append({
-                    "role": "tool",
+                    "role": "user",
                     "content": [{
                         "type": "tool_result",
-                        "id": content_block.id,
+                        "tool_use_id": content_block.id,
                         "content": json.dumps(result, ensure_ascii=False),
                     }]
                 })

--- a/examples/anthropic/anthropic_with_pre_planned_tool.py
+++ b/examples/anthropic/anthropic_with_pre_planned_tool.py
@@ -80,7 +80,12 @@ def main() -> None:
                 # Add tool call to message list
                 messages.append({
                     "role": "assistant",
-                    "content": [content_block.model_dump()]
+                    "content": [{
+                        "type": "tool_use",
+                        "id": content_block.id,
+                        "name": content_block.name,
+                        "input": content_block.input,
+                    }]
                 })
 
                 # Execute tool call
@@ -101,7 +106,11 @@ def main() -> None:
                 # Add tool call result to message list
                 messages.append({
                     "role": "tool",
-                    "content": [{"type": "text", "text": f"Tool {content_block.name} returned: {result}"}]
+                    "content": [{
+                        "type": "tool_result",
+                        "id": content_block.id,
+                        "content": str(result),
+                    }]
                 })
 
         # If no tool call, this is the final response, exit loop


### PR DESCRIPTION
- Added a loop to the existing code that integrates ACI tools with the anthropic framework, enabling automatic invocation of ACI tools within the loop
- Tools involved: GITHUB__STAR_REPOSITORY and GITHUB__GET_USER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced interaction with the Anthropic model to support iterative conversations and multiple tool calls in a single session.
  - Now retrieves and displays both repository starring and owner information as requested by the user.

- **Bug Fixes**
  - Improved error handling during tool execution, ensuring errors are captured and displayed.

- **Style**
  - Updated output to clearly present assistant responses and tool call results throughout the conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->