### PR TITLE
refactor(llamaindex): enhance example with multi-tool support as well as user-friendly process and output

### DIFF
--- a/examples/llamaindex/llamaindex_with_pre_planned_tool.py
+++ b/examples/llamaindex/llamaindex_with_pre_planned_tool.py
@@ -19,7 +19,7 @@ if not LINKED_ACCOUNT_OWNER_ID:
 def github_star_repository(owner: str, repo: str) -> str:
     """Star a GitHub repository by providing the owner and repo name"""
     rprint(Panel("Function Call: github_star_repo", style="bold yellow"))
-    rprint(f"Parameters: owner = {owner}, repo = {repo}")
+    rprint(f"Parameters(github_star_repo): owner = {owner}, repo = {repo}")
     aci = ACI()
 
     result = aci.handle_function_call(
@@ -28,20 +28,60 @@ def github_star_repository(owner: str, repo: str) -> str:
         linked_account_owner_id=LINKED_ACCOUNT_OWNER_ID,
         format=FunctionDefinitionFormat.OPENAI,
     )
-    rprint(Panel("Function Call Result", style="bold magenta"))
+    rprint(Panel("Function(GITHUB__STAR_REPOSITORY) Call Result", style="bold magenta"))
+    rprint(result)
+    return json.dumps(result)
+
+def github_get_user(username: str) -> str:
+    """Get a GitHub user by providing the username"""
+    rprint(Panel("Function Call: github_get_user", style="bold yellow"))
+    rprint(f"Parameters(github_get_user): username = {username}")
+    aci = ACI()
+
+    result = aci.handle_function_call(
+        "GITHUB__GET_USER",
+        {"path": {"username": username}},
+        linked_account_owner_id=LINKED_ACCOUNT_OWNER_ID,
+        format=FunctionDefinitionFormat.OPENAI,
+    )
+    rprint(Panel("Function(GITHUB__GET_USER) Call Result", style="bold magenta"))
     rprint(result)
     return json.dumps(result)
 
 
+# GITHUB__GET_REPOSITORY_LANGUAGES
+def github_get_repository_languages(owner: str, repo: str) -> str:
+    """Get the languages used in a GitHub repository by providing the owner and repo name"""
+    rprint(Panel("Function Call: github_get_repository_languages", style="bold yellow"))
+    rprint(f"Parameters(github_get_repository_languages): owner = {owner}, repo = {repo}")
+    aci = ACI()
+    
+    result = aci.handle_function_call(
+        "GITHUB__GET_REPOSITORY_LANGUAGES",
+        {"path": {"owner": owner, "repo": repo}},
+        linked_account_owner_id=LINKED_ACCOUNT_OWNER_ID,
+        format=FunctionDefinitionFormat.OPENAI,
+    )
+    rprint(Panel("Function(GITHUB__GET_REPOSITORY_LANGUAGES) Call Result", style="bold magenta"))
+    rprint(result)
+    return json.dumps(result)
+
+
+
 async def main() -> None:
     agent = FunctionAgent(
-        tools=[github_star_repository],
+        tools=[github_star_repository, github_get_user, github_get_repository_languages],
         llm=OpenAI(model="gpt-4o-mini"),
         system_prompt="You are a helpful assistant that can use available tools to help the user.",
     )
 
-    response = await agent.run("Star the repo https://github.com/aipotheosis-labs/aci")
+    response = await agent.run("Star the repo https://github.com/aipotheosis-labs/aci and get the languages used in the repo, then get the user info for aipotheosis-labs.")
+    
+    # Format the output
+    rprint(Panel("🤖 Raw Output", style="bold blue"))
     rprint(response)
+    rprint(Panel("🤖 Text Output", style="bold blue"))
+    print(response)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Key improvements:**
- Convert single tool example to multi-tool demonstration:
   _add github_get_user tool and github_get_repository_languages alongside existing github_star_repository_
- Provide more  user-friendly process and output printing

**Comparison of runtime results:**
- **Before improvement:**
  <img width="855" alt="08ff53d6c5aa05d51be4cbe1cd32509" src="https://github.com/user-attachments/assets/44351bc4-3642-4d3c-b4c0-52c332203e0e" />
  <img width="835" alt="9f8be6155793055ad35cc7c218993e8" src="https://github.com/user-attachments/assets/bd95303e-ae13-4e1b-a326-3d4e4d26a156" />

- **After improvement:**
  <img width="920" alt="df3eec702262feb0af41b5fc08c46c9" src="https://github.com/user-attachments/assets/e56b2e5f-ded4-477e-8dc6-66b3c69e817b" />
  <img width="921" alt="2729bada5b01699229a421b17304c74" src="https://github.com/user-attachments/assets/1f928bff-0bff-4336-bfc0-ccb329123a0c" />
  <img width="914" alt="f6f2de7311309ecb01a6093042b7f15" src="https://github.com/user-attachments/assets/3215f33f-6a7b-4e31-a99c-6ae15d2774bd" />
  <img width="920" alt="3b852623a7d8a88304ec7936ebd1a0a" src="https://github.com/user-attachments/assets/c298e50a-63bc-4cea-acbd-e3b557a0003a" />
  <img width="908" alt="39f2c0c06cefbf5faf0c435afe388cb" src="https://github.com/user-attachments/assets/cd6c3396-6c4b-4d0f-86c4-aa17e171c949" />
  <img width="918" alt="f5ca97ef15defed56acf3fc0df9a437" src="https://github.com/user-attachments/assets/7fef69a9-ef82-4aa3-9254-b563468e8147" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve GitHub user information.
  - Added the ability to fetch programming languages used in a GitHub repository.

- **Enhancements**
  - Improved debug and output formatting for function calls and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->