### PR TITLE
refactor(openai-agents): enhance example with multi-tool support

### DIFF
--- a/examples/openai-agents/agent.py
+++ b/examples/openai-agents/agent.py
@@ -38,21 +38,21 @@ def get_tool(function_name: str, linked_account_owner_id: str) -> FunctionTool:
         description=description,
         params_json_schema=parameters,
         on_invoke_tool=tool_impl,
-        strict_json_schema=True,
+        strict_json_schema=False,  # turn off strict json schema validation to allow for optional parameters
     )
 
 
 github_agent = Agent(
     name="github_agent",
     instructions="You are a helpful assistant that can use available tools to help the user.",
-    tools=[get_tool("GITHUB__STAR_REPOSITORY", LINKED_ACCOUNT_OWNER_ID)],
+    tools=[get_tool("GITHUB__STAR_REPOSITORY", LINKED_ACCOUNT_OWNER_ID), get_tool("BRAVE_SEARCH__WEB_SEARCH", LINKED_ACCOUNT_OWNER_ID)],
 )
 
 
 async def main() -> None:
     result = await Runner.run(
         starting_agent=github_agent,
-        input="Star the repo https://github.com/aipotheosis-labs/aci",
+        input="Can you use brave search to find top 5 results about aipolabs ACI? Then star the repo https://github.com/aipotheosis-labs/aci.",
     )
     print(result)
 


### PR DESCRIPTION
**Key improvements:**
- Convert single tool example to multi-tool demonstration: update task description
- Changed strict_json_schema=False in the get_tool() to allow for optional parameters
   ISSUE:  OpenAI Agents framework threw a schema validation error when adding `BRAVE_SEARCH__WEB_SEARCH` tool, but `GITHUB__STAR_REPOSITORY` worked fine.
   CAUSE: When `strict_json_schema=True`, OpenAI requires the required array to include ALL properties defined in the schema, not just the mandatory ones.
   EXAMPLES:
   GitHub Function ✅ Works:
   ```python
   "properties": {
    "repo": {...},
    "owner": {...}
    },
   "required": ["owner", "repo"]  // All properties are required
   ```
   BraveSearch Function ❌ Fails:
    ```python
   "properties": {
    "q": {...},
    "count": {...},
    "offset": {...},
    "safesearch": {...},
    "extra_snippets": {...}
    },
    "required": ["q"]  // Missing "count", "offset", etc.
     ```
   ERROR MESSAGE:
   ```text
   'required' is required to be supplied and to be an array including every key in properties. Missing 'count'.
   ```
**Comparison of runtime results:**
- **Before improvement:**
  ![image](https://github.com/user-attachments/assets/3c9bf2e0-7e83-4da2-b0a7-be5c0729ac95)
- **After improvement:**
  ![image](https://github.com/user-attachments/assets/7619ff44-23df-4371-8d79-4cf7545926c6)
